### PR TITLE
Ranking output: New Phase 1 features

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,25 +1,33 @@
 import pandas as pd
-# import numpy as np
-from scipy.stats import iqr
+from enum import StrEnum
 
 # List of ZIP codes in which we are currently interested:
 zip_codes = [98403, 98404, 98405, 98406, 98407, 98408, 98409, 98418, 98422, 98465, 98424, 98466, 98467, 98332, 98335]
 # Result 9-12-25: 98408, center-south Tacoma, is where annual *growth* is above county average but *rent* is below median.
 
+class ExpectedColumns(StrEnum):
+    ZIP = "Zip"
+    COUNTY = "County"
+    STATE = "State"
+    DATE = "Date"
+    RENT = "Rent"
+    VALUE = "Value"
+    ANNUAL_GROWTH_BY_ZIP = "Annual_Growth_By_Zip"
+
 def aggregate_analysis(df, metric):
-    # Core functionality for Project Falcon #1: based on aggregate rental market index, identify
-    # 1) Annualized % growth (average and median) aggregated for 1a) county and 1b) state,
-    # 2) Absolute index value IQR today by county, and
-    # 3) Zip codes where the annual growth has been above county average since 1/2024 but where the absolute
-    # index value is below the median for the county.
+    """Core functionality for Project Falcon #1: based on aggregate rental market index, identify
+    1) Annualized % growth (average and median) aggregated for 1a) county and 1b) state,
+    2) Absolute index value IQR today by county, and
+    3) Zip codes where the annual growth has been above county average since 1/2024 but where the absolute
+    index value is below the median for the county."""
     
     if metric != metric.title():
         metric = metric.title()
-    if metric not in ["Rent", "Value"]:
-        return print("Please specify how to aggregate: in terms of 'rent' or home 'value'.")
+    if metric not in [ExpectedColumns.RENT, ExpectedColumns.VALUE]:
+        raise ValueError("Please specify how to aggregate: in terms of 'rent' or home 'value'.")
     
-    if not df.columns.to_list() == ["Zip", "County", "State", "Date", metric]:
-        return print("Error: dataframe should contain only the five columns Zip, County, State, Date, and either Rent or Value.")
+    if not df.columns.to_list() == [ExpectedColumns.ZIP, ExpectedColumns.COUNTY, ExpectedColumns.STATE, ExpectedColumns.DATE, metric]:
+        raise ValueError("Error: dataframe should contain only the five columns Zip, County, State, Date, and either Rent or Value.")
 
     df["Date"] = pd.to_datetime(df["Date"]) # Ensuring that the date column is converted to datetime objects
 
@@ -31,11 +39,9 @@ def aggregate_analysis(df, metric):
 
     df = annualized_growth_by_locale(df, metric)
 
-    current_iqr_by_county(df, metric)
+    print_current_iqr(df, metric)
 
-    compare_rent_or_value_and_growth(df, metric)
-
-    # compare_rent_or_value_and_growth(df, above_median=True)       
+    compare_metric_and_growth(df, metric)    
 
 
 def annualized_growth_by_locale(df, metric):
@@ -61,46 +67,54 @@ def annualized_growth_by_locale(df, metric):
     return df
 
 
-def current_iqr_by_county(df, metric):
-    # First, filter the dataframe, indexed to date, by most recent date using max().
+def print_current_iqr(df, metric, group="County"):
+    # Prints Q1, Q3, and IQR of rent/value. Defaults to grouping by county.
+    def q1(group):
+        return group.quantile(0.25)
+    
+    def q3(group):
+        return group.quantile(0.75)
+    
+    def iqr(group):
+        return group.quantile(0.75) - group.quantile(0.25)
+    
+    f = {metric: [q1, q3, iqr]}
+    
+    # Filter the dataframe, indexed to date, by most recent date using max().
     most_recent_df = df[df.index == df.index.max()]
 
+    # Apply aggregate functions to filtered dataframe to assign multi-index columns.
+    quartiles_df = most_recent_df.groupby(group).agg(f)
+
+    # Flatten multi-index columns back into a 2-dimensional dataframe for ease of reference.
+    quartiles_df.columns = list(map('_'.join, quartiles_df.columns.values))
+
     # Next, print the IQR of the rent in this subset, grouped by county.
-    quartiles_by_county = most_recent_df.groupby("County")[metric].quantile([0.25, 0.75])
-    print(f"{metric} 1st and 3rd Quartiles for most recent date by county: \n {quartiles_by_county}")
-
-    # Scipy's iqr() behavior is peculiar here: I need to transform(iqr) and then sum() the quartiles, grouping each time.
-    iqr_by_county = quartiles_by_county.groupby("County").transform(iqr)
-    iqr_by_county = iqr_by_county.groupby("County").sum()
-    print(f"{metric} IQR for most recent date by county: \n{iqr_by_county}")
+    print(f"{metric} Quartiles and IQR for most recent date by {group}: \n {quartiles_df}")
 
 
-def compare_rent_or_value_and_growth(df, metric, above_median=False):
+def check_for_growth_by_zip(df):
+    # Multiple functions rely on annualized_growth_by_locale generating the "Annual_Growth_by_Zip" column, so check for it.
+    if ExpectedColumns.ANNUAL_GROWTH_BY_ZIP not in df.columns.to_list():
+        raise ValueError("Function expects Annual_Growth_by_Zip column. Call annualized_growth_by_locale first.")
+    
+
+def compare_metric_and_growth(df, metric, above_median=False):
     # Filter out before 1/2024 and find above-average rent-growth and below-median rent. First, filter the dates.
     target_date = pd.to_datetime("2024-01-01")
     after_2024_df = df[df.index >= target_date]
     metric_lower = metric.lower()
 
     # Next, identify ZIP codes where growth is above county average.
-    # If annualized_growth_by_locale has been called, the "Annual_Growth_By_Zip" column will exist. If not, define it.
-    try:
-        avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
-    except:
-        df["Annual_Growth_By_Zip"] = (df.groupby("Zip")["Rent"].pct_change(periods=12, fill_method=None) * 100)
-        avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
+    check_for_growth_by_zip(df)
+    avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     above_avg_growth_df = avg_growth_df > avg_growth_df.mean()
     above_avg_growth_zips = above_avg_growth_df[above_avg_growth_df].index.to_list()
     print(f"ZIP codes in which {metric_lower} growth is above average: {above_avg_growth_zips}")
 
-    # Now, identify a separate list of zips where the most recent month's value is below-median, or above if specified.
+    # Identify a separate list of zips where the most recent month's value is below-median, or above if specified.
     most_recent_value = after_2024_df.groupby("Zip")[metric].last()
-    most_recent_median_value = most_recent_value.median()
-    if above_median:
-        median_comparison_string = "above"
-        median_value_comparison_df = most_recent_value > most_recent_median_value
-    else:
-        median_comparison_string = "below"
-        median_value_comparison_df = most_recent_value < most_recent_median_value
+    median_comparison_string, median_value_comparison_df = _check_above_or_below_median(most_recent_value, above_median)
     median_value_zips = median_value_comparison_df[median_value_comparison_df].index.to_list()
     print(f"ZIP codes in which most recent {metric_lower} is {median_comparison_string} median: {median_value_zips}")
 
@@ -117,6 +131,17 @@ def compare_rent_or_value_and_growth(df, metric, above_median=False):
     print(f"ZIP codes ranked in order of higher {metric_lower} growth averaged with lower recent {metric_lower}: \n{sorted_rank_comparison_df}")
 
 
+def _check_above_or_below_median(recent_values, above_median):
+    most_recent_median_values = recent_values.median()
+    if above_median:
+        median_comparison_string = "above"
+        median_value_comparison_df = recent_values > most_recent_median_values
+    else:
+        median_comparison_string = "below"
+        median_value_comparison_df = recent_values < most_recent_median_values
+    return median_comparison_string, median_value_comparison_df
+
+
 def compare_price_to_rent(price_data, rent_data):
     # Ranking of ZIP codes' price-to-rent ratio and percentile ranking of price-to-rent ratio and higher rent growth.
     if "Date" not in price_data.columns.to_list() or "Date" not in rent_data.columns.to_list():
@@ -128,12 +153,8 @@ def compare_price_to_rent(price_data, rent_data):
     sorted_price_to_rent_by_zip = price_to_rent_by_zip.sort_values(ascending=True)
     print(f"ZIP codes ranked in ascending order of price-to-rent ratio: \n{sorted_price_to_rent_by_zip}")
 
-    # If annualized_growth_by_locale has been called, the "Annual_Growth_By_Zip" column will exist. If not, define it.
-    try:
-        avg_rent_growth_df = rent_data.groupby("Zip")["Annual_Growth_By_Zip"].mean()
-    except:
-        rent_data["Annual_Growth_By_Zip"] = (rent_data.groupby("Zip")["Rent"].pct_change(periods=12, fill_method=None) * 100)
-        avg_rent_growth_df = rent_data.groupby("Zip")["Annual_Growth_By_Zip"].mean()
+    check_for_growth_by_zip(rent_data)
+    avg_rent_growth_df = rent_data.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     
     # Percentile ranking of ZIP codes in terms of higher rent growth and lower price-to-rent ratio.
     avg_growth_pct_rank = avg_rent_growth_df.rank(pct=True)
@@ -177,5 +198,5 @@ def zillow_data_parser(data, metric):
 rent_df = zillow_data_parser("zillow_rent_data.csv", "rent")
 price_df = zillow_data_parser("zillow_sfh_value_data.csv", "value")
 # compare_price_to_rent(price_df, rent_df)
-# aggregate_analysis(rent_df, "rent")
-aggregate_analysis(price_df, "value")
+aggregate_analysis(rent_df, "rent")
+# aggregate_analysis(price_df, "value")

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ def compare_rent_and_growth(df, above_median=False):
     try:
         avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     except:
-        df["Annual_Growth_By_Zip"] = (df.groupby("Zip")["Rent"].pct_change(periods=12) * 100)
+        df["Annual_Growth_By_Zip"] = (df.groupby("Zip")["Rent"].pct_change(periods=12, fill_method=None) * 100)
         avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     above_avg_growth_df = avg_growth_df > avg_growth_df.mean()
     above_avg_growth_zips = above_avg_growth_df[above_avg_growth_df].index.to_list()
@@ -97,7 +97,6 @@ def compare_rent_and_growth(df, above_median=False):
         median_rent_comparison_df = most_recent_rent < most_recent_median_rent
     median_rent_zips = median_rent_comparison_df[median_rent_comparison_df].index.to_list()
     print(f"ZIP codes in which most recent rent is {median_comparison_string} median: {median_rent_zips}")
-    # store series/dict indexed to zip containing median rent growth ranked by furthest below median (?)
 
     # Lastly, find common elements of both lists using set intersection.
     intersecting_zips = list(set(above_avg_growth_zips).intersection(median_rent_zips))
@@ -112,8 +111,39 @@ def compare_rent_and_growth(df, above_median=False):
     print(f"ZIP codes ranked in order of higher rent growth averaged with lower recent rent: \n{sorted_rank_comparison_df}")
 
 
-def zillow_data_parser(data):
-    # A wrapper function specifically to parse our Zillow housing data and feed it into aggregate_rents_by_zip().
+def compare_price_to_rent(price_data, rent_data):
+    # Ranking of ZIP codes' price-to-rent ratio and percentile ranking of price-to-rent ratio and higher rent growth.
+    if "Date" not in price_data.columns.to_list() or "Date" not in rent_data.columns.to_list():
+        return print("Error: datasets should be parsed to contain a 'Date' column and be pivoted long.")
+    
+    avg_home_value_by_zip = price_data.groupby("Zip")["Value"].mean()
+    avg_rent_by_zip = rent_data.groupby("Zip")["Rent"].mean()
+    price_to_rent_by_zip = avg_home_value_by_zip / avg_rent_by_zip
+    sorted_price_to_rent_by_zip = price_to_rent_by_zip.sort_values(ascending=True)
+    print(f"ZIP codes ranked in ascending order of price-to-rent ratio: \n{sorted_price_to_rent_by_zip}")
+
+    # If annualized_growth_by_locale has been called, the "Annual_Growth_By_Zip" column will exist. If not, define it.
+    try:
+        avg_rent_growth_df = rent_data.groupby("Zip")["Annual_Growth_By_Zip"].mean()
+    except:
+        rent_data["Annual_Growth_By_Zip"] = (rent_data.groupby("Zip")["Rent"].pct_change(periods=12, fill_method=None) * 100)
+        avg_rent_growth_df = rent_data.groupby("Zip")["Annual_Growth_By_Zip"].mean()
+    
+    # Percentile ranking of ZIP codes in terms of higher rent growth and lower price-to-rent ratio.
+    avg_growth_pct_rank = avg_rent_growth_df.rank(pct=True)
+    price_to_rent_pct_rank = price_to_rent_by_zip.rank(pct=True, ascending=False)
+    rank_comparison_df = pd.concat([avg_growth_pct_rank, price_to_rent_pct_rank], axis=1)
+    rank_comparison_df.rename(columns={rank_comparison_df.columns[0]: "Avg_Growth_Pct_Rank", rank_comparison_df.columns[1]: "Price_to_Rent_Pct_Rank"}, inplace=True)
+    rank_comparison_df["Combined_Rank"] = (rank_comparison_df["Avg_Growth_Pct_Rank"] + rank_comparison_df["Price_to_Rent_Pct_Rank"]) / 2
+    sorted_rank_comparison_df = rank_comparison_df.sort_values(by="Combined_Rank", ascending=False).dropna(subset="Combined_Rank")
+    print(f"ZIP codes ranked in order of higher rent growth averaged with lower price-to-rent ratio: \n{sorted_rank_comparison_df}")
+
+
+def zillow_data_parser(data, metric):
+    # A wrapper function specifically to parse our Zillow housing data and feed it into an aggregation function.
+    if metric.lower() not in ["rent", "value"]:
+        return print("Please specify if this Zillow dataset concerns 'rent' or home 'value'.")
+    
     df = pd.read_csv(data, delimiter=",")
 
     # Zillow data is wide: there's a column for each month of data. I'll convert it to long format for analysis.
@@ -132,9 +162,11 @@ def zillow_data_parser(data):
                       id_vars=["Zip", "County", "State"],
                       value_vars=renamed_df.iloc[:, 3:-1],
                       var_name="Date",
-                      value_name="Rent")
+                      value_name=metric.title())
     return long_df
 
 
-long_df = zillow_data_parser("zillow_data.csv")
-aggregate_rent_analysis(long_df)
+rent_df = zillow_data_parser("zillow_rent_data.csv", "rent")
+price_df = zillow_data_parser("zillow_sfh_value_data.csv", "value")
+# compare_price_to_rent(price_df, rent_df)
+# aggregate_rent_analysis(rent_df)

--- a/main.py
+++ b/main.py
@@ -6,15 +6,20 @@ from scipy.stats import iqr
 zip_codes = [98403, 98404, 98405, 98406, 98407, 98408, 98409, 98418, 98422, 98465, 98424, 98466, 98467, 98332, 98335]
 # Result 9-12-25: 98408, center-south Tacoma, is where annual *growth* is above county average but *rent* is below median.
 
-def aggregate_rent_analysis(df):
+def aggregate_analysis(df, metric):
     # Core functionality for Project Falcon #1: based on aggregate rental market index, identify
     # 1) Annualized % growth (average and median) aggregated for 1a) county and 1b) state,
     # 2) Absolute index value IQR today by county, and
     # 3) Zip codes where the annual growth has been above county average since 1/2024 but where the absolute
     # index value is below the median for the county.
-
-    if not df.columns.to_list() == ["Zip", "County", "State", "Date", "Rent"]:
-        return print("Error: dataframe should contain only the five columns Zip, County, State, Date, and Rent.")
+    
+    if metric != metric.title():
+        metric = metric.title()
+    if metric not in ["Rent", "Value"]:
+        return print("Please specify how to aggregate: in terms of 'rent' or home 'value'.")
+    
+    if not df.columns.to_list() == ["Zip", "County", "State", "Date", metric]:
+        return print("Error: dataframe should contain only the five columns Zip, County, State, Date, and either Rent or Value.")
 
     df["Date"] = pd.to_datetime(df["Date"]) # Ensuring that the date column is converted to datetime objects
 
@@ -24,31 +29,31 @@ def aggregate_rent_analysis(df):
     # Index dataframe to date, thereby dropping "Date" column and helping to analyze over time.
     df = df.set_index("Date")
 
-    df = annualized_growth_by_locale(df)
+    df = annualized_growth_by_locale(df, metric)
 
-    current_rent_iqr_by_county(df)
+    current_iqr_by_county(df, metric)
 
-    compare_rent_and_growth(df)
+    compare_rent_or_value_and_growth(df, metric)
 
-    compare_rent_and_growth(df, above_median=True)       
+    # compare_rent_or_value_and_growth(df, above_median=True)       
 
 
-def annualized_growth_by_locale(df):
+def annualized_growth_by_locale(df, metric):
     # Aggregate annualized growth in rent by county, state, and zip, adding columns and printing mean/medians.
-    df["Annual_Growth_By_County"] = (df.groupby("County")["Rent"].pct_change(periods=12) * 100)
+    df["Annual_Growth_By_County"] = (df.groupby("County")[metric].pct_change(periods=12) * 100)
     grouped_growth_by_county = df.groupby("County")["Annual_Growth_By_County"]
     mean_growth_by_county = grouped_growth_by_county.mean()
     median_growth_by_county = df.groupby("County")["Annual_Growth_By_County"].median()
     print(f"Mean annualized percent growth by county: \n{mean_growth_by_county}")
     print(f"Median annualized percent growth by county: \n{median_growth_by_county}")
 
-    df["Annual_Growth_By_State"] = (df.groupby("State")["Rent"].pct_change(periods=12) * 100)
+    df["Annual_Growth_By_State"] = (df.groupby("State")[metric].pct_change(periods=12) * 100)
     mean_growth_by_state = df.groupby("State")["Annual_Growth_By_State"].mean()
     median_growth_by_state = df.groupby("State")["Annual_Growth_By_State"].median()
     print(f"Mean annualized percent growth by state: \n{mean_growth_by_state}")
     print(f"Median annualized percent growth by state: \n{median_growth_by_state}")
 
-    df["Annual_Growth_By_Zip"] = (df.groupby("Zip")["Rent"].pct_change(periods=12) * 100)
+    df["Annual_Growth_By_Zip"] = (df.groupby("Zip")[metric].pct_change(periods=12) * 100)
     mean_growth_by_zip = df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     median_growth_by_zip = df.groupby("Zip")["Annual_Growth_By_Zip"].median()
     print(f"Mean annualized percent growth by Zip:\n {mean_growth_by_zip}")
@@ -56,24 +61,25 @@ def annualized_growth_by_locale(df):
     return df
 
 
-def current_rent_iqr_by_county(df):
+def current_iqr_by_county(df, metric):
     # First, filter the dataframe, indexed to date, by most recent date using max().
     most_recent_df = df[df.index == df.index.max()]
 
     # Next, print the IQR of the rent in this subset, grouped by county.
-    rent_quartiles_by_county = most_recent_df.groupby("County")["Rent"].quantile([0.25, 0.75])
-    print(f"Rent 1st and 3rd Quartiles for most recent date by county: \n {rent_quartiles_by_county}")
+    quartiles_by_county = most_recent_df.groupby("County")[metric].quantile([0.25, 0.75])
+    print(f"{metric} 1st and 3rd Quartiles for most recent date by county: \n {quartiles_by_county}")
 
     # Scipy's iqr() behavior is peculiar here: I need to transform(iqr) and then sum() the quartiles, grouping each time.
-    rent_iqr_by_county = rent_quartiles_by_county.groupby("County").transform(iqr)
-    rent_iqr_by_county = rent_iqr_by_county.groupby("County").sum()
-    print(f"Rent IQR for most recent date by county: \n{rent_iqr_by_county}")
+    iqr_by_county = quartiles_by_county.groupby("County").transform(iqr)
+    iqr_by_county = iqr_by_county.groupby("County").sum()
+    print(f"{metric} IQR for most recent date by county: \n{iqr_by_county}")
 
 
-def compare_rent_and_growth(df, above_median=False):
+def compare_rent_or_value_and_growth(df, metric, above_median=False):
     # Filter out before 1/2024 and find above-average rent-growth and below-median rent. First, filter the dates.
     target_date = pd.to_datetime("2024-01-01")
     after_2024_df = df[df.index >= target_date]
+    metric_lower = metric.lower()
 
     # Next, identify ZIP codes where growth is above county average.
     # If annualized_growth_by_locale has been called, the "Annual_Growth_By_Zip" column will exist. If not, define it.
@@ -84,31 +90,31 @@ def compare_rent_and_growth(df, above_median=False):
         avg_growth_df = after_2024_df.groupby("Zip")["Annual_Growth_By_Zip"].mean()
     above_avg_growth_df = avg_growth_df > avg_growth_df.mean()
     above_avg_growth_zips = above_avg_growth_df[above_avg_growth_df].index.to_list()
-    print(f"ZIP codes in which rent growth is above average: {above_avg_growth_zips}")
+    print(f"ZIP codes in which {metric_lower} growth is above average: {above_avg_growth_zips}")
 
-    # Now, identify a separate list of zips where the most recent month of rent is below-median, or above if specified.
-    most_recent_rent = after_2024_df.groupby("Zip")["Rent"].last() # series of most recent rents by zip
-    most_recent_median_rent = most_recent_rent.median()
+    # Now, identify a separate list of zips where the most recent month's value is below-median, or above if specified.
+    most_recent_value = after_2024_df.groupby("Zip")[metric].last()
+    most_recent_median_value = most_recent_value.median()
     if above_median:
         median_comparison_string = "above"
-        median_rent_comparison_df = most_recent_rent > most_recent_median_rent
+        median_value_comparison_df = most_recent_value > most_recent_median_value
     else:
         median_comparison_string = "below"
-        median_rent_comparison_df = most_recent_rent < most_recent_median_rent
-    median_rent_zips = median_rent_comparison_df[median_rent_comparison_df].index.to_list()
-    print(f"ZIP codes in which most recent rent is {median_comparison_string} median: {median_rent_zips}")
+        median_value_comparison_df = most_recent_value < most_recent_median_value
+    median_value_zips = median_value_comparison_df[median_value_comparison_df].index.to_list()
+    print(f"ZIP codes in which most recent {metric_lower} is {median_comparison_string} median: {median_value_zips}")
 
     # Lastly, find common elements of both lists using set intersection.
-    intersecting_zips = list(set(above_avg_growth_zips).intersection(median_rent_zips))
-    print(f"ZIP codes in which rent growth is above average and rent is {median_comparison_string} median: {intersecting_zips}")
+    intersecting_zips = list(set(above_avg_growth_zips).intersection(median_value_zips))
+    print(f"ZIP codes in which {metric_lower} growth is above average and {metric_lower} is {median_comparison_string} median: {intersecting_zips}")
 
     # Percentile ranking of ZIP codes in terms of higher rent growth and lower recent rent.
     avg_growth_pct_rank = avg_growth_df.rank(pct=True)
-    recent_rent_pct_rank = most_recent_rent.rank(pct=True, ascending=False)
-    rank_comparison_df = pd.concat([avg_growth_pct_rank, recent_rent_pct_rank], axis=1)
-    rank_comparison_df["Combined_Rank"] = (rank_comparison_df["Annual_Growth_By_Zip"] + rank_comparison_df["Rent"]) / 2
+    recent_value_pct_rank = most_recent_value.rank(pct=True, ascending=False)
+    rank_comparison_df = pd.concat([avg_growth_pct_rank, recent_value_pct_rank], axis=1)
+    rank_comparison_df["Combined_Rank"] = (rank_comparison_df["Annual_Growth_By_Zip"] + rank_comparison_df[metric]) / 2
     sorted_rank_comparison_df = rank_comparison_df.sort_values(by="Combined_Rank", ascending=False).dropna(subset="Combined_Rank")
-    print(f"ZIP codes ranked in order of higher rent growth averaged with lower recent rent: \n{sorted_rank_comparison_df}")
+    print(f"ZIP codes ranked in order of higher {metric_lower} growth averaged with lower recent {metric_lower}: \n{sorted_rank_comparison_df}")
 
 
 def compare_price_to_rent(price_data, rent_data):
@@ -141,7 +147,9 @@ def compare_price_to_rent(price_data, rent_data):
 
 def zillow_data_parser(data, metric):
     # A wrapper function specifically to parse our Zillow housing data and feed it into an aggregation function.
-    if metric.lower() not in ["rent", "value"]:
+    if metric != metric.title():
+        metric = metric.title()
+    if metric not in ["Rent", "Value"]:
         return print("Please specify if this Zillow dataset concerns 'rent' or home 'value'.")
     
     df = pd.read_csv(data, delimiter=",")
@@ -169,4 +177,5 @@ def zillow_data_parser(data, metric):
 rent_df = zillow_data_parser("zillow_rent_data.csv", "rent")
 price_df = zillow_data_parser("zillow_sfh_value_data.csv", "value")
 # compare_price_to_rent(price_df, rent_df)
-# aggregate_rent_analysis(rent_df)
+# aggregate_analysis(rent_df, "rent")
+aggregate_analysis(price_df, "value")

--- a/main.py
+++ b/main.py
@@ -28,7 +28,9 @@ def aggregate_rent_analysis(df):
 
     current_rent_iqr_by_county(df)
 
-    compare_rent_and_growth(df)    
+    compare_rent_and_growth(df)
+
+    compare_rent_and_growth(df, above_median=True)       
 
 
 def annualized_growth_by_locale(df):
@@ -68,7 +70,7 @@ def current_rent_iqr_by_county(df):
     print(f"Rent IQR for most recent date by county: \n{rent_iqr_by_county}")
 
 
-def compare_rent_and_growth(df):
+def compare_rent_and_growth(df, above_median=False):
     # Filter out before 1/2024 and find above-average rent-growth and below-median rent. First, filter the dates.
     target_date = pd.to_datetime("2024-01-01")
     after_2024_df = df[df.index >= target_date]
@@ -84,17 +86,22 @@ def compare_rent_and_growth(df):
     above_avg_growth_zips = above_avg_growth_df[above_avg_growth_df].index.to_list()
     print(f"ZIP codes in which rent growth is above average: {above_avg_growth_zips}")
 
-    # Now, identify a separate list of zips where the most recent month of rent is below-median.
+    # Now, identify a separate list of zips where the most recent month of rent is below-median, or above if specified.
     most_recent_rent = after_2024_df.groupby("Zip")["Rent"].last() # series of most recent rents by zip
     most_recent_median_rent = most_recent_rent.median()
-    below_median_rent_df = most_recent_rent < most_recent_median_rent
-    below_median_rent_zips = below_median_rent_df[below_median_rent_df].index.to_list()
-    print(f"ZIP codes in which most recent rent is below median: {below_median_rent_zips}")
+    if above_median:
+        median_comparison_string = "above"
+        median_rent_comparison_df = most_recent_rent > most_recent_median_rent
+    else:
+        median_comparison_string = "below"
+        median_rent_comparison_df = most_recent_rent < most_recent_median_rent
+    median_rent_zips = median_rent_comparison_df[median_rent_comparison_df].index.to_list()
+    print(f"ZIP codes in which most recent rent is {median_comparison_string} median: {median_rent_zips}")
     # store series/dict indexed to zip containing median rent growth ranked by furthest below median (?)
 
     # Lastly, find common elements of both lists using set intersection.
-    intersecting_zips = list(set(above_avg_growth_zips).intersection(below_median_rent_zips))
-    print(f"ZIP codes in which rent growth is above average and rent is below median: {intersecting_zips}")
+    intersecting_zips = list(set(above_avg_growth_zips).intersection(median_rent_zips))
+    print(f"ZIP codes in which rent growth is above average and rent is {median_comparison_string} median: {intersecting_zips}")
 
     # Percentile ranking of ZIP codes in terms of higher rent growth and lower recent rent.
     avg_growth_pct_rank = avg_growth_df.rank(pct=True)

--- a/main.py
+++ b/main.py
@@ -90,10 +90,19 @@ def compare_rent_and_growth(df):
     below_median_rent_df = most_recent_rent < most_recent_median_rent
     below_median_rent_zips = below_median_rent_df[below_median_rent_df].index.to_list()
     print(f"ZIP codes in which most recent rent is below median: {below_median_rent_zips}")
+    # store series/dict indexed to zip containing median rent growth ranked by furthest below median (?)
 
     # Lastly, find common elements of both lists using set intersection.
     intersecting_zips = list(set(above_avg_growth_zips).intersection(below_median_rent_zips))
     print(f"ZIP codes in which rent growth is above average and rent is below median: {intersecting_zips}")
+
+    # Percentile ranking of ZIP codes in terms of higher rent growth and lower recent rent.
+    avg_growth_pct_rank = avg_growth_df.rank(pct=True)
+    recent_rent_pct_rank = most_recent_rent.rank(pct=True, ascending=False)
+    rank_comparison_df = pd.concat([avg_growth_pct_rank, recent_rent_pct_rank], axis=1)
+    rank_comparison_df["Combined_Rank"] = (rank_comparison_df["Annual_Growth_By_Zip"] + rank_comparison_df["Rent"]) / 2
+    sorted_rank_comparison_df = rank_comparison_df.sort_values(by="Combined_Rank", ascending=False).dropna(subset="Combined_Rank")
+    print(f"ZIP codes ranked in order of higher rent growth averaged with lower recent rent: \n{sorted_rank_comparison_df}")
 
 
 def zillow_data_parser(data):


### PR DESCRIPTION
This branch contains the following new features, as written in our minutes:

- Ranking your prior output: See if you can come up with a ranking of all (within the area of interest) zips according to our criteria. Only one passed the criteria, but which was the second closest to passing (even if it didn’t)? Third?
- Same thing as before but ABOVE-median rent, rather than below-median.
- Same thing but with home value / purchase price instead of rent index, i.e., Above-average rent growth; Below-median home value relative to e.g., County (or perhaps has to be City…we’ll iterate more)
- Ranking candidate zip codes in terms of price-to-rent ratio / perhaps also secondarily ranking by something else (e.g., rent growth, home value, etc.)? Price-to-rent is just mean(home_value) / mean(rental_rate) for a given set of properties. Obviously ideal if they’re homogeneous (not comparing studio condo to 4bd house) but probably impossible.